### PR TITLE
PYMT-1610: XML Parser Failure Mitigation

### DIFF
--- a/src/Exceptions/ImpossibleException.php
+++ b/src/Exceptions/ImpossibleException.php
@@ -16,7 +16,7 @@ final class ImpossibleException extends RuntimeException
      */
     public function getErrorCode(): int
     {
-        return self::DEFAULT_ERROR_CODE_RUNTIME + 999;
+        return self::DEFAULT_ERROR_CODE_RUNTIME + 899;
     }
 
     /**

--- a/src/Exceptions/ImpossibleException.php
+++ b/src/Exceptions/ImpossibleException.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace EoneoPay\BankFiles\Exceptions;
+
+use EoneoPay\Utils\Exceptions\RuntimeException;
+
+/**
+ * An exception for a situation that should never happen (null checks when it is known
+ * that it will never be null, etc).
+ */
+final class ImpossibleException extends RuntimeException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorCode(): int
+    {
+        return self::DEFAULT_ERROR_CODE_RUNTIME + 999;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getErrorSubCode(): int
+    {
+        return 1;
+    }
+}

--- a/src/Helpers/XmlFailureMitigation.php
+++ b/src/Helpers/XmlFailureMitigation.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace EoneoPay\BankFiles\Helpers;
 
+use EoneoPay\BankFiles\Exceptions\ImpossibleException;
+
 /**
  * A helper class that works to mitigate XML-related issues.
  */
@@ -14,6 +16,8 @@ class XmlFailureMitigation
      * @param string $content The XML content.
      *
      * @return string
+     *
+     * @throws \EoneoPay\BankFiles\Exceptions\ImpossibleException
      */
     public static function tryMitigateParseFailures(string $content): string
     {
@@ -35,7 +39,10 @@ class XmlFailureMitigation
                 if (\count($match) !== 3) {
                     // @codeCoverageIgnoreStart
                     // Sanity check only and unable to be tested.
-                    continue;
+                    throw new ImpossibleException(\sprintf(
+                        'Regular expression match result should have 3 children, %d found.',
+                        \count($match)
+                    ));
                     // @codeCoverageIgnoreEnd
                 }
 

--- a/src/Helpers/XmlFailureMitigation.php
+++ b/src/Helpers/XmlFailureMitigation.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace EoneoPay\BankFiles\Helpers;
+
+/**
+ * A helper class that works to mitigate XML-related issues.
+ */
+class XmlFailureMitigation
+{
+    /**
+     * Attempts to work around common data inconsistencies that the banks find acceptable (for some odd reason).
+     *
+     * @param string $content The XML content.
+     *
+     * @return string
+     */
+    public static function tryMitigateParseFailures(string $content): string
+    {
+        // Split the content in to individual lines
+        $lines = \explode(\PHP_EOL, \trim($content));
+
+        // Iterate through each line from the content string
+        foreach ($lines as &$line) {
+            // Find any matching node element name and content in the line
+            $result = \preg_match_all('/<([A-Za-z0-9-_]+)?(?:[^\>]+)?>(.*)<\/\1>/', $line, $matches, \PREG_SET_ORDER);
+            if ($result === false || $result === 0) {
+                continue;
+            }
+
+            // Begin to iterate through each node key and value
+            // We assume here that there *could* be more than one XML element in a given line.
+            foreach ($matches as $match) {
+                // If the match does not contain three elements, skip
+                if (\count($match) !== 3) {
+                    // @codeCoverageIgnoreStart
+                    // Sanity check only and unable to be tested.
+                    continue;
+                    // @codeCoverageIgnoreEnd
+                }
+
+                $matched = $match[0];
+                $value = $match[2];
+
+                // Check if the value contains any HTML characters which would cause XML parsing issues
+                if (\preg_match('//', $value) > 0) {
+                    $value = \htmlentities($value);
+                }
+
+                // If the value has not been modified, continue
+                if ($value === $match[2]) {
+                    continue;
+                }
+
+                // Update the line with the new value
+                $replacement = \str_replace($match[2], $value, $matched);
+                $line = \str_replace($matched, $replacement, $line);
+            }
+        }
+
+        return \implode(\PHP_EOL, $lines);
+    }
+}

--- a/src/Parsers/Ack/AbaParser.php
+++ b/src/Parsers/Ack/AbaParser.php
@@ -6,7 +6,6 @@ namespace EoneoPay\BankFiles\Parsers\Ack;
 use EoneoPay\BankFiles\Parsers\Ack\Results\PaymentAcknowledgement;
 use EoneoPay\Utils\Arr;
 use EoneoPay\Utils\Collection;
-use EoneoPay\Utils\XmlConverter;
 
 class AbaParser extends Parser
 {
@@ -19,10 +18,9 @@ class AbaParser extends Parser
      */
     protected function process(): void
     {
-        $xmlConverter = new XmlConverter();
         $arr = new Arr();
 
-        $result = $xmlConverter->xmlToArray($this->contents, 1);
+        $result = $this->convertXmlToArray($this->contents);
 
         $this->acknowledgement = new PaymentAcknowledgement([
             'attributes' => $arr->get($result, '@attributes'),

--- a/src/Parsers/Ack/BpbParser.php
+++ b/src/Parsers/Ack/BpbParser.php
@@ -6,7 +6,6 @@ namespace EoneoPay\BankFiles\Parsers\Ack;
 use EoneoPay\BankFiles\Parsers\Ack\Results\PaymentAcknowledgement;
 use EoneoPay\Utils\Arr;
 use EoneoPay\Utils\Collection;
-use EoneoPay\Utils\XmlConverter;
 
 class BpbParser extends Parser
 {
@@ -19,10 +18,9 @@ class BpbParser extends Parser
      */
     protected function process(): void
     {
-        $xmlConverter = new XmlConverter();
         $arr = new Arr();
 
-        $result = $xmlConverter->xmlToArray($this->contents, 1);
+        $result = $this->convertXmlToArray($this->contents);
 
         $this->acknowledgement = new PaymentAcknowledgement([
             'attributes' => $arr->get($result, '@attributes'),

--- a/src/Parsers/Ack/Parser.php
+++ b/src/Parsers/Ack/Parser.php
@@ -12,6 +12,9 @@ use EoneoPay\Utils\Exceptions\InvalidXmlException;
 use EoneoPay\Utils\Interfaces\CollectionInterface;
 use EoneoPay\Utils\XmlConverter;
 
+/**
+ * @SuppressWarnings(PHPMD.StaticAccess) Ignore static access to XML mitigation.
+ */
 abstract class Parser extends BaseParser
 {
     /**
@@ -56,23 +59,23 @@ abstract class Parser extends BaseParser
      *
      * @param string $xml
      *
-     * @return mixed[]|null
+     * @return mixed[]
      *
      * @throws \EoneoPay\Utils\Exceptions\InvalidXmlException
      */
-    protected function convertXmlToArray(string $xml): ?array
+    protected function convertXmlToArray(string $xml): array
     {
         $xmlConverter = new XmlConverter();
 
         try {
-            $result = $xmlConverter->xmlToArray($this->contents, 1);
+            $result = $xmlConverter->xmlToArray($xml, 1);
         } catch (InvalidXmlException $exception) {
             // When an exception is thrown, let's attempt to mitigate the issue by cleaning up some common
             // inconsistencies from the bank's side.
-            $fixedContents = XmlFailureMitigation::tryMitigateParseFailures($this->contents);
+            $fixedContents = XmlFailureMitigation::tryMitigateParseFailures($xml);
 
-            // If the content back from mitigation is null, throw the initial exception
-            if ($fixedContents === null || $fixedContents === '') {
+            // If the content back from mitigation is empty, throw the initial exception
+            if ($fixedContents === '') {
                 throw $exception;
             }
 

--- a/src/Parsers/Ack/Parser.php
+++ b/src/Parsers/Ack/Parser.php
@@ -3,11 +3,14 @@ declare(strict_types=1);
 
 namespace EoneoPay\BankFiles\Parsers\Ack;
 
+use EoneoPay\BankFiles\Helpers\XmlFailureMitigation;
 use EoneoPay\BankFiles\Parsers\Ack\Results\Issue;
 use EoneoPay\BankFiles\Parsers\Ack\Results\PaymentAcknowledgement;
 use EoneoPay\BankFiles\Parsers\BaseParser;
 use EoneoPay\Utils\Arr;
+use EoneoPay\Utils\Exceptions\InvalidXmlException;
 use EoneoPay\Utils\Interfaces\CollectionInterface;
+use EoneoPay\Utils\XmlConverter;
 
 abstract class Parser extends BaseParser
 {
@@ -46,6 +49,38 @@ abstract class Parser extends BaseParser
     public function getPaymentAcknowledgement(): PaymentAcknowledgement
     {
         return $this->acknowledgement;
+    }
+
+    /**
+     * Attempts to convert the provided XML string to an array.
+     *
+     * @param string $xml
+     *
+     * @return mixed[]|null
+     *
+     * @throws \EoneoPay\Utils\Exceptions\InvalidXmlException
+     */
+    protected function convertXmlToArray(string $xml): ?array
+    {
+        $xmlConverter = new XmlConverter();
+
+        try {
+            $result = $xmlConverter->xmlToArray($this->contents, 1);
+        } catch (InvalidXmlException $exception) {
+            // When an exception is thrown, let's attempt to mitigate the issue by cleaning up some common
+            // inconsistencies from the bank's side.
+            $fixedContents = XmlFailureMitigation::tryMitigateParseFailures($this->contents);
+
+            // If the content back from mitigation is null, throw the initial exception
+            if ($fixedContents === null || $fixedContents === '') {
+                throw $exception;
+            }
+
+            // Run the converter again, this time not capturing any exceptions
+            $result = $xmlConverter->xmlToArray($fixedContents, 1);
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Exceptions/ImpossibleExceptionTest.php
+++ b/tests/Exceptions/ImpossibleExceptionTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\BankFiles\Exceptions;
+
+use EoneoPay\BankFiles\Exceptions\ImpossibleException;
+use Tests\EoneoPay\BankFiles\TestCases\TestCase;
+
+/**
+ * @covers \EoneoPay\BankFiles\Exceptions\ImpossibleException
+ */
+class ImpossibleExceptionTest extends TestCase
+{
+    /**
+     * Tests that the exception codes match the expected.
+     *
+     * @return void
+     */
+    public function testExceptionCodes(): void
+    {
+        $exception = new ImpossibleException();
+
+        self::assertSame(1999, $exception->getCode());
+        self::assertSame(1, $exception->getErrorSubCode());
+    }
+}

--- a/tests/Exceptions/ImpossibleExceptionTest.php
+++ b/tests/Exceptions/ImpossibleExceptionTest.php
@@ -20,7 +20,7 @@ class ImpossibleExceptionTest extends TestCase
     {
         $exception = new ImpossibleException();
 
-        self::assertSame(1999, $exception->getCode());
+        self::assertSame(1999, $exception->getErrorCode());
         self::assertSame(1, $exception->getErrorSubCode());
     }
 }

--- a/tests/Generators/TestCase.php
+++ b/tests/Generators/TestCase.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Tests\EoneoPay\BankFiles\Generators;
 
-use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Tests\EoneoPay\BankFiles\TestCases\TestCase as BaseTestCase;
 
-class TestCase extends PHPUnitTestCase
+class TestCase extends BaseTestCase
 {
 }

--- a/tests/Helpers/XmlFailureMitigationTest.php
+++ b/tests/Helpers/XmlFailureMitigationTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\BankFiles\Helpers;
+
+use EoneoPay\BankFiles\Helpers\XmlFailureMitigation;
+use Tests\EoneoPay\BankFiles\TestCases\TestCase;
+
+/**
+ * @covers \EoneoPay\BankFiles\Helpers\XmlFailureMitigation
+ */
+class XmlFailureMitigationTest extends TestCase
+{
+    /**
+     * Gets the XML scenarios for testing.
+     *
+     * @return mixed[]
+     */
+    public function getXmlScenarios(): iterable
+    {
+        yield 'HTML-like characters in node value' => [
+            'input' => <<<'XML'
+<PaymentsAcknowledgement type="warning">
+    <Issues>
+        <Issue type="test">This is a very <1> important <test> issue.</Issue>
+    </Issues>
+</PaymentsAcknowledgement>
+XML,
+            'expected' => <<<'XML'
+<PaymentsAcknowledgement type="warning">
+    <Issues>
+        <Issue type="test">This is a very &lt;1&gt; important &lt;test&gt; issue.</Issue>
+    </Issues>
+</PaymentsAcknowledgement>
+XML
+        ];
+    }
+
+    /**
+     * Tests that the helper method successfully handles the provided scenarios.
+     *
+     * @param string $input
+     * @param string $expected
+     *
+     * @return void
+     *
+     * @dataProvider getXmlScenarios
+     */
+    public function testMitigationReplacesInvalidLines(string $input, string $expected): void
+    {
+        $result = XmlFailureMitigation::tryMitigateParseFailures($input);
+
+        self::assertSame($expected, $result);
+    }
+
+    /**
+     * Test that the helper class does not touch valid XML.
+     *
+     * @return void
+     */
+    public function testMitigationLeavesValidXmlAlone(): void
+    {
+        $xml = <<<'XML'
+<PaymentsAcknowledgement type="info">
+<PaymentId>94829970</PaymentId>
+<OriginalMessageId>94829954</OriginalMessageId>
+<DateTime>2017/10/17</DateTime>
+<CustomerId>LOYC01AU</CustomerId>
+<CompanyName>Loyalty Corp Australia Pty Ltd</CompanyName>
+<UserMessage>Payment status is PROCESSED WITH INVALID TRANSACTIONS</UserMessage>
+<DetailedMessage>Payment has been successfully processed and invalid items have been returned to your account.</DetailedMessage>
+<OriginalFilename>credit-mer_584aaa43110d77d1b224c20a20171016_221504.txt.ENC</OriginalFilename>
+<OriginalReference>Encrypted file</OriginalReference>
+<Issues>
+<Issue type="2025">Payment 105205350 successfully uploaded from a file.</Issue>
+<Issue type="2025">Payment 105205350 successfully uploaded from a file.</Issue>
+<Issue type="104503">Payment successfully validated.</Issue>
+<Issue type="181301">Payment is ready to be submitted for processing.</Issue>
+</Issues>
+</PaymentsAcknowledgement>
+XML;
+
+        $result = XmlFailureMitigation::tryMitigateParseFailures($xml);
+
+        self::assertSame($xml, $result);
+    }
+}

--- a/tests/Helpers/XmlFailureMitigationTest.php
+++ b/tests/Helpers/XmlFailureMitigationTest.php
@@ -8,6 +8,8 @@ use Tests\EoneoPay\BankFiles\TestCases\TestCase;
 
 /**
  * @covers \EoneoPay\BankFiles\Helpers\XmlFailureMitigation
+ *
+ * @SuppressWarnings(PHPMD.StaticAccess) Ignore static access to XML mitigation.
  */
 class XmlFailureMitigationTest extends TestCase
 {
@@ -37,29 +39,14 @@ XML
     }
 
     /**
-     * Tests that the helper method successfully handles the provided scenarios.
-     *
-     * @param string $input
-     * @param string $expected
-     *
-     * @return void
-     *
-     * @dataProvider getXmlScenarios
-     */
-    public function testMitigationReplacesInvalidLines(string $input, string $expected): void
-    {
-        $result = XmlFailureMitigation::tryMitigateParseFailures($input);
-
-        self::assertSame($expected, $result);
-    }
-
-    /**
      * Test that the helper class does not touch valid XML.
      *
      * @return void
      */
     public function testMitigationLeavesValidXmlAlone(): void
     {
+        // phpcs:disable
+        // Disabled to ignore long lines in XML sample.
         $xml = <<<'XML'
 <PaymentsAcknowledgement type="info">
 <PaymentId>94829970</PaymentId>
@@ -79,9 +66,27 @@ XML
 </Issues>
 </PaymentsAcknowledgement>
 XML;
+        // phpcs:enable
 
         $result = XmlFailureMitigation::tryMitigateParseFailures($xml);
 
         self::assertSame($xml, $result);
+    }
+
+    /**
+     * Tests that the helper method successfully handles the provided scenarios.
+     *
+     * @param string $input
+     * @param string $expected
+     *
+     * @return void
+     *
+     * @dataProvider getXmlScenarios
+     */
+    public function testMitigationReplacesInvalidLines(string $input, string $expected): void
+    {
+        $result = XmlFailureMitigation::tryMitigateParseFailures($input);
+
+        self::assertSame($expected, $result);
     }
 }

--- a/tests/Parsers/Ack/data/invalid_node_value_sample.txt.ENC.PENDING.ACK
+++ b/tests/Parsers/Ack/data/invalid_node_value_sample.txt.ENC.PENDING.ACK
@@ -1,0 +1,20 @@
+<PaymentsAcknowledgement type="warning">
+<PaymentId>1234567890</PaymentId>
+<OriginalMessageId>1234567890</OriginalMessageId>
+<DateTime>2020/01/01</DateTime>
+<CustomerId>CUST01</CustomerId>
+<CompanyName>Test Company</CompanyName>
+<UserMessage>Payment status is REQUIRES AUTHORISATION</UserMessage>
+<DetailedMessage>Payment requires customer authorisation. Log into NAB Connect to review and authorise payment.</DetailedMessage>
+<OriginalFilename>PAYMENTGATEWAY_1234567890_1024_20200101230050437250</OriginalFilename>
+<Issues>
+<Issue type="290049">Uploaded Interchange 111111111 for Customer 123456 and Payment Type DL_DIRECTCREDIT.</Issue>
+<Issue type="2025">Payment 111111111 successfully uploaded from a file.</Issue>
+<Issue type="2025">Payment 111111111 successfully uploaded from a file.</Issue>
+<Issue type="104503">Payment successfully validated.</Issue>
+<Issue type="181026">The BSB 777-777 is invalid.</Issue>
+<Issue type="181022">Counter transaction <4> created due to transaction <1> having invalid account name, BSB or account number.</Issue>
+<Issue type="181015">Payment ID 111111111 has partially failed account validation.</Issue>
+<Issue type="6010">Payment is ready for authorisation - 1 authorisations required.</Issue>
+</Issues>
+</PaymentsAcknowledgement>

--- a/tests/Parsers/TestCase.php
+++ b/tests/Parsers/TestCase.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Tests\EoneoPay\BankFiles\Parsers;
 
+use Tests\EoneoPay\BankFiles\TestCases\TestCase as BaseTestCase;
 use Mockery\LegacyMockInterface;
-use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
@@ -12,7 +12,7 @@ use ReflectionProperty;
 /**
  * @SuppressWarnings(PHPMD.NumberOfChildren) All Tests extend this class
  */
-class TestCase extends PHPUnitTestCase
+class TestCase extends BaseTestCase
 {
     /**
      * Get mock for given class and set expectations based on given callable.

--- a/tests/Parsers/TestCase.php
+++ b/tests/Parsers/TestCase.php
@@ -3,11 +3,11 @@ declare(strict_types=1);
 
 namespace Tests\EoneoPay\BankFiles\Parsers;
 
-use Tests\EoneoPay\BankFiles\TestCases\TestCase as BaseTestCase;
 use Mockery\LegacyMockInterface;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionProperty;
+use Tests\EoneoPay\BankFiles\TestCases\TestCase as BaseTestCase;
 
 /**
  * @SuppressWarnings(PHPMD.NumberOfChildren) All Tests extend this class

--- a/tests/TestCases/TestCase.php
+++ b/tests/TestCases/TestCase.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\BankFiles\TestCases;
+
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+/**
+ * The base test case.
+ */
+class TestCase extends PHPUnitTestCase
+{
+}


### PR DESCRIPTION
This PR implements a method of mitigating XML parsing issues in malformed bank files.

For some reason, some bank files will contain invalid syntax in places it just should not be - we cannot help that, so we need to work around it.

Example:
```
<PaymentAcknowledgement>
    <Issues>
        <Issue type="123">Wow I love <1> placeholders <2> in XML values!</Issue>
    </Issues>
</PaymentAcknowledgement>
```

The mitigation works to remove these sorts of things where the XML has initially failed to parse. Upon a second failure, the resulting `InvalidXmlException` is left to run rampant intentionally.

**Ticket:** https://eonx.atlassian.net/browse/PAY-1610